### PR TITLE
Remove current ip only or add parameter all

### DIFF
--- a/orb/apprl-circleci-tools/remove-ips-from-sg.sh
+++ b/orb/apprl-circleci-tools/remove-ips-from-sg.sh
@@ -2,8 +2,10 @@
 
 current_security_group=$(aws ec2 describe-security-groups --region $AWS_DEFAULT_REGION --group-id $AWS_SECURITY_GROUP)
 echo "Security group config $current_security_group"
+public_ip_address_with_cidr=$(wget -qO- http://checkip.amazonaws.com)/32
+echo "My ip $public_ip_address_with_cidr"
 ip_count=$(echo ${current_security_group} | jq -r '.SecurityGroups[0].IpPermissions | length')
-if [ ${ip_count} > 0 ]; then
+if [[ ${ip_count} > 0 ]]; then
   for (( n=0; n < $ip_count; n++ ))
   do
     this_port=$(echo ${current_security_group} | jq -r ".SecurityGroups[0].IpPermissions[${n}].FromPort")
@@ -11,8 +13,10 @@ if [ ${ip_count} > 0 ]; then
     for (( c=0; c < $cidr_count; c++ ))
     do
       this_cidr=$(echo ${current_security_group} | jq -r ".SecurityGroups[0].IpPermissions[${n}].IpRanges[${c}].CidrIp")
-      echo "Revoke ip $this_cidr"
-      aws ec2 revoke-security-group-ingress --region ${AWS_DEFAULT_REGION} --group-id $AWS_SECURITY_GROUP --protocol tcp --port ${this_port} --cidr ${this_cidr}
+      if [[ "$this_cidr" == "$public_ip_address_with_cidr" ]] || [[ "$1" == "all" ]]; then
+          echo "Revoke ip $this_cidr"
+          aws ec2 revoke-security-group-ingress --region ${AWS_DEFAULT_REGION} --group-id $AWS_SECURITY_GROUP --protocol tcp --port ${this_port} --cidr ${this_cidr}
+      fi
     done
   done
 fi


### PR DESCRIPTION
The default behaviour is changed to remove only the current ip adress instead of all for the specific security group. Add parameter "all" to the command if you want to remove all ips from the security group.